### PR TITLE
Add v1.22 create token command

### DIFF
--- a/documentation/kube-dashboard.md
+++ b/documentation/kube-dashboard.md
@@ -134,6 +134,16 @@ We need a service account to access the K8S Dashboard.
 
 To access the Dashboard, we need to have a token from the `cluster-admin-dashboard` service account.
 
+As referenced in: https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets
+    as of Kubernetes v1.22 a secret is not dynamically generated when a service account is created.
+    First, try:
+    
+    ```console
+    debian@busybox:~$ kubectl create token cluster-admin-dashboard -n kubernetes-dashboard
+    ```
+    
+    If a token is successfully generated, move on to "View the Dashboard" Section.
+
 1. Query secrets
 
    ```console


### PR DESCRIPTION
As of k8s 1.22 a secret is not dynamically generated when a service account is created. Adding reference and command to generate token. FWIW `kubectl create token kubernetes-dashboard -n kube-system` worked for me without the creation of a service account.